### PR TITLE
Amazon RDS DBのホスト名削除

### DIFF
--- a/sql.sh
+++ b/sql.sh
@@ -1,1 +1,1 @@
-mysql -h database-toinfes.c0gwlsggxfl3.ap-northeast-1.rds.amazonaws.com -u admin -p 
+mysql -h example.com -u example -p 


### PR DESCRIPTION
こんにちは。Amazon RDS DBのホスト名が記載されており、安全の為削除すべきだったためリクエストを送信させていただきました。記載ホスト名とユーザーをexampleに置き換えています。

文化祭頑張ってください。